### PR TITLE
change state variables names to be more semantic; include error state…

### DIFF
--- a/src/components/TokenForm.js
+++ b/src/components/TokenForm.js
@@ -4,7 +4,7 @@ import Error from './Error';
 
 const TokenForm = ({ setToken }) => {
   const [tokenInput, setTokenInput] = useState('');
-  const [hidden, setHidden] = useState(true);
+  const [error, setError] = useState(false);
 
   const handleFormSubmit = async (event) => {
     event.preventDefault();
@@ -13,10 +13,10 @@ const TokenForm = ({ setToken }) => {
       .where('tokenName', '==', tokenInput)
       .get();
     if (tokenWeAreCheckingFor.empty) {
-      setHidden(false);
+      setError(true);
     } else {
       localStorage.setItem('userToken', tokenInput);
-      setHidden(true);
+      setError(false);
       setToken(tokenInput);
     }
   };
@@ -35,15 +35,14 @@ const TokenForm = ({ setToken }) => {
               value={tokenInput}
               onChange={(event) => {
                 setTokenInput(event.target.value);
+                setError(false);
               }}
               required
             />
           </label>
           <button type="submit">Join an existing list</button>
         </form>
-        {hidden ? (
-          ''
-        ) : (
+        {error && (
           <Error errorMessage="Hmmm... we couldn't find that list. Please try again or create a new list." />
         )}
       </div>


### PR DESCRIPTION
… change in onchange handler

## Description
This PR will allow users to share tokens and collaborate on other lists. A user can enter an existing token which will be saved to `localStorage`, the corresponding list will be collected from `Firestore` and the user will be redirected to the `list` view. If the list does not exist, the user will receive an error message and will not be redirected. 

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
[#6](https://github.com/the-collab-lab/tcl-17-smart-shopping-list/issues/6)

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria
- [x] When the user does not already have a token in localStorage, on the onboarding/home screen, a simple form is displayed that allows the user to enter a token
- [x] Entering the token and hitting submit saves the token to localStorage, effectively giving them joint control of the list
- [x] On submit, show an error if the token does not exist
- [x] If they get an error message, allow them to try again or create a new list

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :sparkles: New feature     |


## Updates

### Before
<img width="369" alt="welcome-before" src="https://user-images.githubusercontent.com/36529777/105232284-04f0c800-5b1d-11eb-8d5f-8b78b8b8e60a.PNG">
<!-- If UI feature, take provide screenshots -->

### After
<img width="344" alt="welcome-after" src="https://user-images.githubusercontent.com/36529777/105232328-16d26b00-5b1d-11eb-97a1-fd30fd04db14.PNG">
<img width="394" alt="welcome-error" src="https://user-images.githubusercontent.com/36529777/105232336-19cd5b80-5b1d-11eb-823d-67a72e18d095.PNG">

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
* One way to test the site is to click on the `details` button below to open the Netlify preview.

* Otherwise from your terminal, pull down this branch with git pull origin `BL-DD-join-existing-list` and check that branch out with git checkout `BL-DD-join-existing-list`
* Use `npm start` to launch the app in the browser.

* If you already have a token saved in `localStorage` you will need to clear the token first in order to test this feature. In your developer tools in the browser, navigate to `application`, select `local storage` and hit the `clear` icon to remove any pre-existing tokens from your local storage.

1. First enter `not real token` into the `join an existing list` field to get an error message for a token that doesn't exist in the database.
2. Then enter `chick gould nibs` to join an existing list that does already exist in the database.

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->



