### PR TITLE
Add MaterialUI circular progress component as loading spinner

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -15,6 +15,7 @@ import {
   List as MuiList,
   ListItem,
   ListItemText,
+  CircularProgress,
 } from '@material-ui/core';
 import CircleUnchecked from '@material-ui/icons/RadioButtonUnchecked';
 import CircleCheckedFilled from '@material-ui/icons/CheckCircle';
@@ -151,7 +152,7 @@ const List = ({ token }) => {
     <div className="list-view-container">
       <Header />
       {loading ? (
-        <h1>Loading...</h1>
+        <CircularProgress size={160} />
       ) : (
         <React.Fragment>
           {docs.length === 0 ? (


### PR DESCRIPTION
## Description

This code adds a loading spinner using the Material UI component `CircularProgress`, so that the user sees something more interesting than just the words "Loading..." in black and white when they wait for the list to load.  

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
closes #47 

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria
- [ ] The user sees a spinner instead of the "Loading..." message

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |

## Updates

### Before
![loadingText](https://user-images.githubusercontent.com/11085221/109406781-b959e700-7930-11eb-82f5-5f6466c921ed.gif)

<!-- If UI feature, take provide screenshots -->


### After
![loadingSpinner](https://user-images.githubusercontent.com/11085221/109406782-bced6e00-7930-11eb-8816-5d3dbea3add1.gif)

<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria
* One way to test the site is to click on the `details` button below to open the `Netlify preview`
![Screen Shot 2021-01-12 at 6 05 51 PM](https://user-images.githubusercontent.com/14856004/104389400-ff81f500-5500-11eb-95ae-4c0169a069cb.png)

* Otherwise from your terminal, pull down this branch with `git pull origin RR-add-loading-spinner` and check that branch out with `git checkout RR-RR-add-loading-spinner`
* Run `npm start` in your terminal to launch the application in the browser 
* If you don't have an existing list, you can either:
                1. Enter the token `stroll ames knack` into the Share Token input field and click the Join an Existing List button
                2. Create a new list 
* Upon being redirected to the List page, refresh it and confirm that you see the loading spinner
*  To slow down your network connection and make it easier to see the spinner, you can go to the network tab and click on the dropdown that says "online" and try out one of the slower options instead.
![image](https://user-images.githubusercontent.com/34964885/106321980-fc3d7780-6229-11eb-932f-0c56a857608c.png)
<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

