### PR TITLE
  Delete css rule causing placeholder text to flow into border

### DIFF
--- a/src/styles/List.css
+++ b/src/styles/List.css
@@ -70,10 +70,6 @@ section .add-item-link {
   margin: 0 1rem;
 }
 
-.top-container label {
-  width: 75%;
-}
-
 #reset-button {
   margin-left: 1rem;
 }


### PR DESCRIPTION
## Description
This PR fixes the placeholder text of the input box on the list view.

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
closes #79

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Definition of done : 

- [ ] Text no longer overflows to the border
<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :hammer: Refactoring       |

## Updates

### Before
<img width="316" alt="Screen Shot 2021-02-28 at 10 51 29 AM" src="https://user-images.githubusercontent.com/14856004/109426679-7e00fc00-79b4-11eb-92b4-edbd28240800.png">



<!-- If UI feature, take provide screenshots -->


### After
<img width="322" alt="Screen Shot 2021-02-28 at 10 51 52 AM" src="https://user-images.githubusercontent.com/14856004/109426687-81948300-79b4-11eb-8b0b-34d745195aea.png">




<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria
* One way to test the site is to click on the `details` button below to open the `Netlify preview`

![Screen Shot 2021-01-12 at 6 05 51 PM](https://user-images.githubusercontent.com/14856004/104389400-ff81f500-5500-11eb-95ae-4c0169a069cb.png)

* Otherwise from your terminal, pull down this branch with `git pull origin VT-fix-list-input-text` and check that branch out with `git checkout VT-fix-list-input-text`
* Create a new list or join an existing list
* The list shown uses the token `stroll ames knack`
<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->